### PR TITLE
add places for users to add options

### DIFF
--- a/src/etc/default/xboxdrv
+++ b/src/etc/default/xboxdrv
@@ -10,4 +10,19 @@ TRIGGER_AS_BUTTON=true
 MIMIC_XPAD=true
 
 # Additional options that are passed to xboxdrv (see xboxdrv man pages).
+# These settings are applied to all controller slots
 XBOXDRV_OPTIONS=""
+
+# Use seperate controller slot options
+SEPERATE_CONTROLLER_SLOT_OPTIONS=false
+
+# Edit each block to give each controller slot its own options.
+# If this is selected nothing is entered, the unmodified slots  
+# will default to the options in XBOXDRV_OPTIONS, or will not be
+# configured at all.
+CONTROLLER1_OPTIONS=""                                                                                                                                                                                                                         
+CONTROLLER2_OPTIONS=""
+CONTROLLER3_OPTIONS=""
+CONTROLLER4_OPTIONS=""
+
+# EOF #


### PR DESCRIPTION
-defines old way of adding options to xboxdrv as daemon wide, its probably still useful for debugging but im personally not going to use it.
-adds trigger value to tell init script whether we wil be using seperate controller slot options or not
-adds variables to store each slot's options